### PR TITLE
Hotfix for the Travis Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ services:
   - postgresql
 
 before_install:
-  - wget http://chromedriver.storage.googleapis.com/2.21/chromedriver_linux64.zip
+  - wget http://chromedriver.storage.googleapis.com/2.26/chromedriver_linux64.zip
   - unzip chromedriver_linux64.zip
   - sudo chmod u+x chromedriver
   - sudo mv chromedriver /usr/bin/


### PR DESCRIPTION
I added the social environment variables and changed the version of the chrome driver to match the last release 2.26